### PR TITLE
feat: Implement user plan update functionality

### DIFF
--- a/resources/js/Pages/Profile/Edit.jsx
+++ b/resources/js/Pages/Profile/Edit.jsx
@@ -3,17 +3,19 @@ import { Head } from '@inertiajs/react';
 import DeleteUserForm from './Partials/DeleteUserForm';
 import UpdatePasswordForm from './Partials/UpdatePasswordForm';
 import UpdateProfileInformationForm from './Partials/UpdateProfileInformationForm';
+import UpdatePlanForm from './Partials/UpdatePlanForm'; // Import the new component
 
-export default function Edit({ mustVerifyEmail, status }) {
+export default function Edit({ auth, mustVerifyEmail, status, userPlan, availablePlans }) {
     return (
         <AuthenticatedLayout
+            user={auth.user}
             header={
                 <h2 className="text-xl font-semibold leading-tight text-gray-800">
-                    Profile
+                    Perfil
                 </h2>
             }
         >
-            <Head title="Profile" />
+            <Head title="Perfil" />
 
             <div className="py-12">
                 <div className="mx-auto max-w-7xl space-y-6 sm:px-6 lg:px-8">
@@ -27,6 +29,10 @@ export default function Edit({ mustVerifyEmail, status }) {
 
                     <div className="bg-white p-4 shadow sm:rounded-lg sm:p-8">
                         <UpdatePasswordForm className="max-w-xl" />
+                    </div>
+
+                    <div className="bg-white p-4 shadow sm:rounded-lg sm:p-8">
+                        <UpdatePlanForm className="max-w-xl" userPlan={userPlan} availablePlans={availablePlans} />
                     </div>
 
                     <div className="bg-white p-4 shadow sm:rounded-lg sm:p-8">

--- a/resources/js/Pages/Profile/Partials/UpdatePlanForm.jsx
+++ b/resources/js/Pages/Profile/Partials/UpdatePlanForm.jsx
@@ -1,0 +1,101 @@
+import React, { useState } from 'react';
+import { useForm, usePage } from '@inertiajs/react';
+import PrimaryButton from '@/Components/PrimaryButton';
+import SecondaryButton from '@/Components/SecondaryButton';
+import InputLabel from '@/Components/InputLabel';
+import InputError from '@/Components/InputError';
+import Modal from '@/Components/Modal';
+
+export default function UpdatePlanForm({ className = '' }) {
+    const { auth, userPlan, availablePlans } = usePage().props;
+    const [showingPlansModal, setShowingPlansModal] = useState(false);
+
+    const { data, setData, patch, processing, errors, reset } = useForm({
+        plan_id: userPlan.id,
+    });
+
+    const confirmPlanUpdate = () => {
+        setShowingPlansModal(true);
+    };
+
+    const closeModal = () => {
+        setShowingPlansModal(false);
+        reset();
+    };
+
+    const updatePlan = (planId) => {
+        setData('plan_id', planId);
+        patch(route('profile.updatePlan'), {
+            preserveScroll: true,
+            onSuccess: () => closeModal(),
+            onError: () => reset(),
+        });
+    };
+
+    return (
+        <section className={className}>
+            <header>
+                <h2 className="text-lg font-medium text-gray-900">Información del Plan</h2>
+                <p className="mt-1 text-sm text-gray-600">
+                    Gestiona tu plan de suscripción.
+                </p>
+            </header>
+
+            <div className="mt-6 space-y-6">
+                <div>
+                    <InputLabel value="Plan Actual" />
+                    <p className="mt-1 text-sm text-gray-900">
+                        <span className="font-semibold">{userPlan.name}</span> - ${userPlan.price} / mes
+                    </p>
+                    <ul className="mt-2 text-sm text-gray-600 list-disc list-inside">
+                        {userPlan.features.map(feature => (
+                            <li key={feature.id}>{feature.feature_code.replace(/_/g, ' ')}: {feature.value}</li>
+                        ))}
+                    </ul>
+                </div>
+
+                <div className="flex items-center gap-4">
+                    <PrimaryButton onClick={confirmPlanUpdate}>Actualizar Plan</PrimaryButton>
+                </div>
+            </div>
+
+            <Modal show={showingPlansModal} onClose={closeModal}>
+                <div className="p-6">
+                    <h2 className="text-lg font-medium text-gray-900">
+                        Selecciona un Nuevo Plan
+                    </h2>
+
+                    <p className="mt-1 text-sm text-gray-600">
+                        Compara los planes disponibles y elige el que mejor se adapte a tus necesidades.
+                    </p>
+
+                    <div className="mt-6 grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+                        {availablePlans.map((plan) => (
+                            <div key={plan.id} className="border p-4 rounded-lg shadow-sm flex flex-col">
+                                <h3 className="text-xl font-semibold mb-2">{plan.name}</h3>
+                                <p className="text-3xl font-bold mb-4">${plan.price}<span className="text-base font-medium">/mes</span></p>
+                                <p className="text-sm text-gray-600 mb-4 flex-grow">{plan.description}</p>
+                                <ul className="mb-4 text-sm text-gray-700 list-disc list-inside">
+                                    {plan.features.map(feature => (
+                                        <li key={feature.id}>{feature.feature_code.replace(/_/g, ' ')}: {feature.value}</li>
+                                    ))}
+                                </ul>
+                                {userPlan.id === plan.id ? (
+                                    <SecondaryButton disabled className="w-full">Plan Actual</SecondaryButton>
+                                ) : (
+                                    <PrimaryButton onClick={() => updatePlan(plan.id)} className="w-full" disabled={processing}>
+                                        Seleccionar Plan
+                                    </PrimaryButton>
+                                )}
+                            </div>
+                        ))}
+                    </div>
+
+                    <div className="mt-6 flex justify-end">
+                        <SecondaryButton onClick={closeModal}>Cancelar</SecondaryButton>
+                    </div>
+                </div>
+            </Modal>
+        </section>
+    );
+}

--- a/routes/web.php
+++ b/routes/web.php
@@ -47,6 +47,9 @@ Route::middleware('auth')->group(function () {
     Route::patch('/profile', [ProfileController::class, 'update'])->name('profile.update');
     Route::delete('/profile', [ProfileController::class, 'destroy'])->name('profile.destroy');
 
+    // Rutas para actualizar el plan del usuario
+    Route::patch('/profile/plan', [ProfileController::class, 'updatePlan'])->name('profile.updatePlan');
+
     // Rutas para Configuración de Seguridad
     Route::get('/seguridad', [ProfileController::class, 'security'])->name('profile.security');
     Route::patch('/seguridad', [ProfileController::class, 'updateSecurity'])->name('profile.updateSecurity');


### PR DESCRIPTION
This commit introduces the ability for users to update their subscription plan through the profile settings.

-   Added a new route `/profile/plan` to handle the plan update request.
-   Created an `updatePlan` method in the `ProfileController` to process the plan update. This method validates the request, updates the user's `plan_id`, and redirects back to the profile edit page with a success message.
-   Modified the `edit` method in `ProfileController` to fetch available plans and the user's current plan, passing them to the `Profile/Edit` Inertia component.
-   Imported and integrated a new `UpdatePlanForm` component in `resources/js/Pages/Profile/Edit.jsx` to display the available plans and handle the update submission.