### PR TITLE
Register posthumous message command and fix storage disk reference

### DIFF
--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -19,6 +19,13 @@ class Kernel extends ConsoleKernel
     /**
      * Register the commands for the application.
      */
+    protected $commands = [
+        \App\Console\Commands\EnviarMensajesPostumos::class,
+    ];
+
+    /**
+     * Register the commands for the application.
+     */
     protected function commands(): void
     {
         $this->load(__DIR__.'/Commands');

--- a/app/Mail/MensajePostumoEmail.php
+++ b/app/Mail/MensajePostumoEmail.php
@@ -55,7 +55,7 @@ class MensajePostumoEmail extends Mailable
 
         if ($this->mensajePostumo->ruta_archivo) {
             $attachments[] = \Illuminate\Mail\Mailables\Attachment::fromStorageDisk(
-                'private', // O el disco que uses para los archivos
+                'local', // O el disco que uses para los archivos
                 $this->mensajePostumo->ruta_archivo
             );
         }


### PR DESCRIPTION
- Add EnviarMensajesPostumos command to Kernel commands array
- Change attachment storage disk from 'private' to 'local' in MensajePostumoEmail