### PR TITLE
Add scheduler execution logging with timestamp and timezone

### DIFF
--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -13,6 +13,8 @@ class Kernel extends ConsoleKernel
      */
     protected function schedule(Schedule $schedule): void
     {
+        \Illuminate\Support\Facades\Log::info('Scheduler running at: ' . \Carbon\Carbon::now()->toDateTimeString() . ' (' . \Carbon\Carbon::now()->timezoneName . ')');
+
         $schedule->command(EnviarMensajesPostumos::class)->everyMinute();
     }
 


### PR DESCRIPTION
Log scheduler runs with current datetime and timezone information for better monitoring and debugging of scheduled tasks.