### PR TITLE
Improve CSRF token handling in video recorder

### DIFF
--- a/resources/js/Pages/VideoRecorder.jsx
+++ b/resources/js/Pages/VideoRecorder.jsx
@@ -75,11 +75,18 @@ export default function VideoRecorder({ auth }) {
                 formData.append('video', blob, 'recorded-video.mp4');
 
                 try {
+                    const csrfToken = window.Laravel.csrfToken;
+                    if (!csrfToken) {
+                        console.error('CSRF token not found.');
+                        alert('Error de seguridad: CSRF token no encontrado. Por favor, recarga la página.');
+                        return;
+                    }
+
                     const response = await fetch(route('mensajes-postumos.uploadVideoTemp'), {
                         method: 'POST',
                         body: formData,
                         headers: {
-                            'X-CSRF-TOKEN': document.querySelector('meta[name="csrf-token"]').getAttribute('content'),
+                            'X-CSRF-TOKEN': csrfToken,
                             'X-Requested-With': 'XMLHttpRequest',
                         },
                         credentials: 'include',

--- a/resources/views/app.blade.php
+++ b/resources/views/app.blade.php
@@ -14,6 +14,11 @@
 
         <!-- Scripts -->
         @routes
+        <script>
+            window.Laravel = {!! json_encode([
+                'csrfToken' => csrf_token(),
+            ]) !!};
+        </script>
         @viteReactRefresh
         @vite(['resources/js/app.jsx', "resources/js/Pages/{$page['component']}.jsx"])
         @inertiaHead


### PR DESCRIPTION
- Add CSRF token to global Laravel object in app.blade.php
- Update VideoRecorder to use global token with error handling
- Add user-friendly error message for missing CSRF token