### PR TITLE
Comment out Oneclick management link in authenticated layout

### DIFF
--- a/resources/js/Layouts/AuthenticatedLayout.jsx
+++ b/resources/js/Layouts/AuthenticatedLayout.jsx
@@ -144,11 +144,11 @@ export default function AuthenticatedLayout({ header, children }) {
                                         >
                                             Actualizar Plan
                                         </Dropdown.Link>
-                                        <Dropdown.Link
+                                        {/* <Dropdown.Link
                                             href={route('profile.oneclick')}
                                         >
                                             Gestionar Oneclick
-                                        </Dropdown.Link>
+                                        </Dropdown.Link> */}
                                         <Dropdown.Link
                                             href={route('proof-of-life.settings.show')}
                                         >


### PR DESCRIPTION
Remove access to Oneclick management functionality from the user dropdown menu by commenting out the corresponding navigation link.